### PR TITLE
Add missing attribute 'name' to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "galera"
 maintainer       "Severalnines AB"
 maintainer_email "support@severalnines.com"
 license          "Apache 2.0"


### PR DESCRIPTION
This missing attribute will cause knife cookbook upload failure. In metadata.json, actually we have such attribute present.